### PR TITLE
Set correct version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-oauth2-provider-keycloak</artifactId>
-    <version>1.10.0</version>
+    <version>1.9.1</version>
 
     <name>Gravitee.io APIM - Resource - OAuth2 Provider - Keycloak Adapter</name>
     <description>The resource is defined to introspect an access token provided by Keycloak.</description>


### PR DESCRIPTION
**Issue**

NA

**Description**

This commit doesn't fix any bugs and was made in order to a release and so fix publication on the download website.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.2-fix-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/1.9.2-fix-version-SNAPSHOT/gravitee-resource-oauth2-provider-keycloak-1.9.2-fix-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
