### PR TITLE
chore: bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -35,13 +35,19 @@
     <description>The resource is defined to introspect an access token provided by Keycloak.</description>
 
     <properties>
-        <gravitee-bom.version>1.1</gravitee-bom.version>
+        <gravitee-bom.version>3.0.24</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.19.1</gravitee-gateway-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
-        <gravitee-node-api.version>1.4.6</gravitee-node-api.version>
-        <keycloak.version>13.0.1</keycloak.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-node-api.version>2.1.1</gravitee-node-api.version>
+
+        <keycloak.version>21.1.2</keycloak.version>
+        <wiremock.version>2.27.2</wiremock.version>
+
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+        <prettier-maven-plugin.version>0.17</prettier-maven-plugin.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
     </properties>
@@ -105,16 +111,6 @@
             <artifactId>keycloak-authz-client</artifactId>
             <version>${keycloak.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.3.1.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
 
         <!-- HTTP client -->
         <dependency>
@@ -148,7 +144,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.19.0</version>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -171,7 +167,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -210,7 +206,7 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>${prettier-maven-plugin.version}</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4308

**Description**

Bump dependencies
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.2`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/1.9.2/gravitee-resource-oauth2-provider-keycloak-1.9.2.zip)
  <!-- Version placeholder end -->
