### PR TITLE
fix(keycloak): Update keycloak version + dependencies upgrade to supp…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXXX
 
 **Description**
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -24,23 +24,27 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>22.0.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-oauth2-provider-keycloak</artifactId>
-    <version>1.9.2</version>
+    <version>2.0.0-apim-4308-keycloak-version-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - OAuth2 Provider - Keycloak Adapter</name>
     <description>The resource is defined to introspect an access token provided by Keycloak.</description>
 
     <properties>
-        <gravitee-bom.version>1.1</gravitee-bom.version>
+        <gravitee-bom.version>6.0.39</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.19.1</gravitee-gateway-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
-        <gravitee-node-api.version>1.4.6</gravitee-node-api.version>
-        <keycloak.version>13.0.1</keycloak.version>
+        <gravitee-gateway-api.version>3.2.3</gravitee-gateway-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-node-api.version>4.8.6</gravitee-node-api.version>
+        <keycloak.version>24.0.5</keycloak.version>
+        <jboss-logging.version>3.5.3.Final</jboss-logging.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <wiremock.version>3.3.1</wiremock.version>
+
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
@@ -108,12 +112,12 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.3.1.Final</version>
+            <version>${jboss-logging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>${httpclient.version}</version>
         </dependency>
 
         <!-- HTTP client -->
@@ -146,9 +150,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.19.0</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -210,19 +214,6 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/assembly/resource-assembly.xml
+++ b/src/assembly/resource-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/oauth2/keycloak/configuration/OAuth2KeycloakResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/oauth2/keycloak/configuration/OAuth2KeycloakResourceConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,50 +1,45 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:resource:oauth2:keycloak:configuration:OAuth2KeycloakResourceConfiguration",
-  "properties" : {
-    "keycloakConfiguration" : {
-      "title": "Keycloak client configuration",
-      "type" : "string",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Place your Keycloak OIDC JSON client adapter configuration here.",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true,
-          "mode": "javascript"
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:resource:oauth2:keycloak:configuration:OAuth2KeycloakResourceConfiguration",
+    "properties": {
+        "keycloakConfiguration": {
+            "title": "Keycloak client configuration",
+            "type": "string",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Place your Keycloak OIDC JSON client adapter configuration here.",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true,
+                    "mode": "javascript"
+                }
+            }
+        },
+        "validateTokenLocally": {
+            "title": "Local token validation",
+            "type": "boolean",
+            "default": true
+        },
+        "userClaim": {
+            "title": "User claim",
+            "description": "User claim field used to store end user on log analytics",
+            "type": "string",
+            "default": "sub"
+        },
+        "verifyHost": {
+            "title": "Verify host",
+            "description": "Of certificate on SSL connection to keycloak host",
+            "type": "boolean",
+            "default": false
+        },
+        "trustAll": {
+            "title": "Trust all",
+            "description": "Trust all certificates, including self-signed ones",
+            "type": "boolean",
+            "default": true
         }
-      }
     },
-    "validateTokenLocally" : {
-      "title": "Local token validation",
-      "type" : "boolean",
-      "default": true
-    },
-    "userClaim" : {
-      "title": "User claim",
-      "description": "User claim field used to store end user on log analytics",
-      "type": "string",
-      "default": "sub"
-    },
-    "verifyHost" : {
-      "title": "Verify host",
-      "description": "Of certificate on SSL connection to keycloak host",
-      "type" : "boolean",
-      "default": false
-    },
-    "trustAll" : {
-      "title": "Trust all",
-      "description": "Trust all certificates, including self-signed ones",
-      "type" : "boolean",
-      "default": true
-    }
-  },
-  "required": [
-    "keycloakConfiguration",
-    "validateTokenLocally",
-    "verifyHost",
-    "trustAll"
-  ]
+    "required": ["keycloakConfiguration", "validateTokenLocally", "verifyHost", "trustAll"]
 }

--- a/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/keycloak.json
+++ b/src/test/resources/keycloak.json
@@ -1,10 +1,10 @@
 {
-  "realm": "gravitee",
-  "auth-server-url": "http://localhost:8080/auth",
-  "ssl-required": "external",
-  "resource": "sdqsdqsdqsd",
-  "credentials": {
-    "secret": "e5e64593-bc18-4cd8-93e6-cd48fc4ad947"
-  },
-  "confidential-port": 0
+    "realm": "gravitee",
+    "auth-server-url": "http://localhost:8080/auth",
+    "ssl-required": "external",
+    "resource": "sdqsdqsdqsd",
+    "credentials": {
+        "secret": "e5e64593-bc18-4cd8-93e6-cd48fc4ad947"
+    },
+    "confidential-port": 0
 }


### PR DESCRIPTION
…ort 4.x

**Issue**

https://gravitee.atlassian.net/browse/APIM-4308

**Description**

Upgrade dependencies + adapt code
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-4308-keycloak-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/2.0.0-apim-4308-keycloak-version-SNAPSHOT/gravitee-resource-oauth2-provider-keycloak-2.0.0-apim-4308-keycloak-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
