### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.oauth2.keycloak.OAuth2KeycloakResource
 type=resource
 icon=keycloack.png
+category=OAuth2

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,19 +1,14 @@
 {
     "type": "object",
-    "id": "urn:jsonschema:io:gravitee:resource:oauth2:keycloak:configuration:OAuth2KeycloakResourceConfiguration",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
         "keycloakConfiguration": {
             "title": "Keycloak client configuration",
             "type": "string",
-            "x-schema-form": {
-                "type": "codemirror",
-                "codemirrorOptions": {
-                    "placeholder": "Place your Keycloak OIDC JSON client adapter configuration here.",
-                    "lineWrapping": true,
-                    "lineNumbers": true,
-                    "allowDropFileTypes": true,
-                    "autoCloseTags": true,
-                    "mode": "javascript"
+            "format": "gio-code-editor",
+            "gioConfig": {
+                "monacoEditorConfig": {
+                    "language": "json"
                 }
             }
         },


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

![image](https://github.com/gravitee-io/gravitee-resource-oauth2-provider-keycloak/assets/4974420/4643fb19-9de0-4718-98b6-054ea5338c11)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/2.1.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-oauth2-provider-keycloak-2.1.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
