### PR TITLE
chore(deps): update dependency bouncy castle to v1.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,11 @@
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
-        <keycloak.version>24.0.5</keycloak.version>
+        <keycloak.version>25.0.3</keycloak.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <httpclient.version>4.5.14</httpclient.version>
         <wiremock.version>3.9.1</wiremock.version>
+        <bouncy-castle.version>1.78</bouncy-castle.version>
 
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
@@ -118,6 +119,18 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+        </dependency>
+        <!-- Override bcprov-jdk18on version for vulnerabilities, used in keycloak-adapter-core -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncy-castle.version}</version>
+        </dependency>
+        <!-- Override bcpkix-jdk18on version for vulnerabilities, used in keycloak-adapter-core -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncy-castle.version}</version>
         </dependency>
 
         <!-- HTTP client -->


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8308

**Description**

Update bouncy castle version.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/2.1.0/gravitee-resource-oauth2-provider-keycloak-2.1.0.zip)
  <!-- Version placeholder end -->
