### PR TITLE
fix: include the scopes when returning the protected resource metadata from the oauth2 policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.5.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <keycloak.version>25.0.3</keycloak.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>

--- a/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
@@ -342,7 +342,7 @@ public class OAuth2KeycloakResource extends OAuth2Resource<OAuth2KeycloakResourc
     }
 
     @Override
-    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri) {
-        return new OAuth2ResourceMetadata(protectedResourceUri, List.of(realmUrl), List.of());
+    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri, List<String> scopesSupported) {
+        return new OAuth2ResourceMetadata(protectedResourceUri, List.of(realmUrl), scopesSupported);
     }
 }

--- a/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
@@ -30,6 +30,7 @@ import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
 import io.gravitee.resource.oauth2.keycloak.configuration.OAuth2KeycloakResourceConfiguration;
 import io.vertx.core.Vertx;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpHeaders;
@@ -281,13 +282,25 @@ public class OAuth2KeycloakResourceTest {
     }
 
     @Test
-    public void testGetProtectedResourceMetadata() {
+    public void testGetProtectedResourceMetadataWithNoScopes() {
         OAuth2KeycloakResource resource = new OAuth2KeycloakResource();
         resource.setRealmUrl("https://some.keycloak.com/realms/test");
-        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", List.of());
         assertEquals("https://backend.com", resourceMetadata.protectedResourceUri());
         assertEquals("https://some.keycloak.com/realms/test", resourceMetadata.authorizationServers().get(0));
         assertEquals(1, resourceMetadata.authorizationServers().size());
         assertTrue(resourceMetadata.scopesSupported().isEmpty());
+    }
+
+    @Test
+    public void testGetProtectedResourceMetadataWithScopes() {
+        OAuth2KeycloakResource resource = new OAuth2KeycloakResource();
+        resource.setRealmUrl("https://some.keycloak.com/realms/test");
+        List<String> scopes = List.of("read", "write", "admin");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", scopes);
+        assertEquals("https://backend.com", resourceMetadata.protectedResourceUri());
+        assertEquals("https://some.keycloak.com/realms/test", resourceMetadata.authorizationServers().get(0));
+        assertEquals(1, resourceMetadata.authorizationServers().size());
+        assertEquals(scopes, resourceMetadata.scopesSupported());
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13671
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-apim-13671-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/3.0.1-apim-13671-SNAPSHOT/gravitee-resource-oauth2-provider-keycloak-3.0.1-apim-13671-SNAPSHOT.zip)
  <!-- Version placeholder end -->
