### PR TITLE
feat: add token exchange support for Keycloak resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.6.0-token-exchange-support-SNAPSHOT</gravitee-resource-oauth2-provider-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <keycloak.version>25.0.3</keycloak.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>

--- a/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResource.java
@@ -26,9 +26,12 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
+import io.gravitee.resource.oauth2.api.OAuth2ResourceException;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeRequest;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeResponse;
 import io.gravitee.resource.oauth2.keycloak.configuration.OAuth2KeycloakResourceConfiguration;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
@@ -37,11 +40,14 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Setter;
 import org.keycloak.adapters.KeycloakDeployment;
@@ -67,6 +73,8 @@ public class OAuth2KeycloakResource extends OAuth2Resource<OAuth2KeycloakResourc
 
     private static final String KEYCLOAK_INTROSPECTION_ENDPOINT = "/protocol/openid-connect/token/introspect";
     private static final String KEYCLOAK_USERINFO_ENDPOINT = "/protocol/openid-connect/userinfo";
+    private static final String KEYCLOAK_TOKEN_ENDPOINT = "/protocol/openid-connect/token";
+    private static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
 
     private static final String HTTPS_SCHEME = "https";
 
@@ -85,6 +93,7 @@ public class OAuth2KeycloakResource extends OAuth2Resource<OAuth2KeycloakResourc
     private String introspectionEndpointURI;
     private String introspectionEndpointAuthorization;
     private String userInfoEndpointURI;
+    private String tokenEndpointURI;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -136,6 +145,9 @@ public class OAuth2KeycloakResource extends OAuth2Resource<OAuth2KeycloakResourc
 
         // Prepare introspection endpoint calls
         introspectionEndpointURI = introspectionUri.getPath() + KEYCLOAK_INTROSPECTION_ENDPOINT;
+
+        // Prepare token exchange endpoint calls — store full absolute URI for Vertx 5 compatibility
+        tokenEndpointURI = realmUrl + KEYCLOAK_TOKEN_ENDPOINT;
         userAgent = NodeUtils.userAgent(applicationContext.getBean(Node.class));
         vertx = applicationContext.getBean(Vertx.class);
     }
@@ -250,6 +262,101 @@ public class OAuth2KeycloakResource extends OAuth2Resource<OAuth2KeycloakResourc
                     }
                 );
         }
+    }
+
+    @Override
+    public void tokenExchange(TokenExchangeRequest tokenExchangeRequest, Handler<TokenExchangeResponse> responseHandler) {
+        // ⚠️ Workaround solution
+        // Vertx 5 removed createHttpClient() overloads; use java.net.http.HttpClient on a worker thread instead.
+        logger.debug("Exchange token by requesting {}", tokenEndpointURI);
+
+        String formBody = toFormBody(tokenExchangeRequest);
+
+        vertx
+            .<String>executeBlocking(() -> {
+                java.net.http.HttpClient javaHttpClient = java.net.http.HttpClient.newHttpClient();
+                java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                    .uri(java.net.URI.create(tokenEndpointURI))
+                    .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED)
+                    .header("Authorization", introspectionEndpointAuthorization)
+                    .header("Accept", MediaType.APPLICATION_JSON)
+                    .header("User-Agent", userAgent)
+                    .POST(java.net.http.HttpRequest.BodyPublishers.ofString(formBody))
+                    .build();
+
+                java.net.http.HttpResponse<String> response = javaHttpClient.send(
+                    request,
+                    java.net.http.HttpResponse.BodyHandlers.ofString()
+                );
+
+                logger.debug("Keycloak token endpoint returns a response with a {} status code", response.statusCode());
+
+                if (response.statusCode() == HttpStatusCode.OK_200) {
+                    return response.body();
+                } else {
+                    throw new OAuth2ResourceException(response.body());
+                }
+            })
+            .onSuccess(body -> handleTokenExchangeSuccess(body, responseHandler))
+            .onFailure(err -> {
+                logger.error("An error occurs while exchanging OAuth2 token", err);
+                responseHandler.handle(new TokenExchangeResponse(err));
+            });
+    }
+
+    private void handleTokenExchangeSuccess(String body, Handler<TokenExchangeResponse> responseHandler) {
+        try {
+            JsonNode payload = MAPPER.readTree(body);
+            TokenExchangeResponse.Builder responseBuilder = TokenExchangeResponse.builder(
+                payload.path("access_token").asText(),
+                payload.path("issued_token_type").asText(),
+                payload.path("token_type").asText()
+            );
+
+            if (payload.hasNonNull("expires_in")) {
+                responseBuilder.expiresIn(payload.path("expires_in").asLong());
+            }
+            if (payload.hasNonNull("scope")) {
+                responseBuilder.scope(payload.path("scope").asText());
+            }
+            if (payload.hasNonNull("refresh_token")) {
+                responseBuilder.refreshToken(payload.path("refresh_token").asText());
+            }
+
+            responseHandler.handle(responseBuilder.build());
+        } catch (IOException ioe) {
+            logger.error("Unable to parse token exchange response payload: {}", body, ioe);
+            responseHandler.handle(new TokenExchangeResponse(ioe));
+        }
+    }
+
+    private String toFormBody(TokenExchangeRequest tokenExchangeRequest) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", TOKEN_EXCHANGE_GRANT_TYPE);
+        form.put("subject_token", tokenExchangeRequest.getSubjectToken());
+        form.put("subject_token_type", tokenExchangeRequest.getSubjectTokenType());
+        putIfPresent(form, "resource", tokenExchangeRequest.getResource());
+        putIfPresent(form, "audience", tokenExchangeRequest.getAudience());
+        putIfPresent(form, "scope", tokenExchangeRequest.getScope());
+        putIfPresent(form, "requested_token_type", tokenExchangeRequest.getRequestedTokenType());
+        putIfPresent(form, "actor_token", tokenExchangeRequest.getActorToken());
+        putIfPresent(form, "actor_token_type", tokenExchangeRequest.getActorTokenType());
+
+        return form
+            .entrySet()
+            .stream()
+            .map(entry -> urlEncode(entry.getKey()) + "=" + urlEncode(entry.getValue()))
+            .collect(Collectors.joining("&"));
+    }
+
+    private void putIfPresent(Map<String, String> form, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            form.put(key, value);
+        }
+    }
+
+    private String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/keycloak/OAuth2KeycloakResourceTest.java
@@ -28,6 +28,8 @@ import io.gravitee.node.api.Node;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeRequest;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeResponse;
 import io.gravitee.resource.oauth2.keycloak.configuration.OAuth2KeycloakResourceConfiguration;
 import io.vertx.core.Vertx;
 import java.util.List;
@@ -52,6 +54,7 @@ public class OAuth2KeycloakResourceTest {
 
     private static final String KEYCLOAK_USERINFO_URI = "/auth/realms/Gravitee/protocol/openid-connect/userinfo";
     private static final String KEYCLOAK_INTROSPECT_TOKEN_URI = "/auth/realms/Gravitee/protocol/openid-connect/token/introspect";
+    private static final String KEYCLOAK_TOKEN_URI = "/auth/realms/Gravitee/protocol/openid-connect/token";
 
     private static final String ADAPTER_CONFIG =
         "{\n" +
@@ -73,6 +76,15 @@ public class OAuth2KeycloakResourceTest {
 
     private static final String EXPECTED_INTROSPECTION_ACTIVE_RESPONSE = "{\"active\": true}";
     private static final String EXPECTED_INTROSPECTION_NONACTIVE_RESPONSE = "{\"active\": false}";
+    private static final String EXPECTED_TOKEN_EXCHANGE_RESPONSE =
+        "{" +
+        "\"access_token\":\"exchanged-token\"," +
+        "\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"," +
+        "\"token_type\":\"Bearer\"," +
+        "\"expires_in\":300," +
+        "\"scope\":\"mcp:tools\"," +
+        "\"refresh_token\":\"refresh-token\"" +
+        "}";
 
     private static class TestResponseHandler<T> implements Handler<T> {
 
@@ -279,6 +291,72 @@ public class OAuth2KeycloakResourceTest {
         assertFalse(handler.getResponse().isSuccess());
 
         verify(getRequestedFor(urlEqualTo(KEYCLOAK_USERINFO_URI)));
+    }
+
+    @Test
+    public void shouldExchangeToken() throws Exception {
+        when(configuration.getKeycloakConfiguration()).thenReturn(String.format(ADAPTER_CONFIG, wireMockRule.port()));
+        when(configuration.isValidateTokenLocally()).thenReturn(false);
+
+        stubFor(post(urlEqualTo(KEYCLOAK_TOKEN_URI)).willReturn(aResponse().withStatus(200).withBody(EXPECTED_TOKEN_EXCHANGE_RESPONSE)));
+
+        resource.doStart();
+
+        final CountDownLatch lock = new CountDownLatch(1);
+        final TestResponseHandler<TokenExchangeResponse> handler = new TestResponseHandler<>(lock);
+
+        TokenExchangeRequest request = TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN)
+            .audience("mcp-upstream")
+            .scope("mcp:tools")
+            .requestedTokenType(TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN)
+            .build();
+
+        resource.tokenExchange(request, handler);
+        assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+
+        assertTrue(handler.getResponse().isSuccess());
+        assertEquals("exchanged-token", handler.getResponse().getAccessToken());
+        assertEquals(TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN, handler.getResponse().getIssuedTokenType());
+        assertEquals("Bearer", handler.getResponse().getTokenType());
+        assertEquals(Long.valueOf(300), handler.getResponse().getExpiresIn());
+        assertEquals("mcp:tools", handler.getResponse().getScope());
+        assertEquals("refresh-token", handler.getResponse().getRefreshToken());
+
+        verify(
+            postRequestedFor(urlEqualTo(KEYCLOAK_TOKEN_URI))
+                .withHeader(HttpHeaders.CONTENT_TYPE, equalTo(MediaType.APPLICATION_FORM_URLENCODED))
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Basic .*"))
+                .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange"))
+                .withRequestBody(containing("subject_token=subject-token"))
+                .withRequestBody(containing("subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token"))
+                .withRequestBody(containing("requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token"))
+                .withRequestBody(containing("audience=mcp-upstream"))
+                .withRequestBody(containing("scope=mcp%3Atools"))
+        );
+    }
+
+    @Test
+    public void shouldFailTokenExchange() throws Exception {
+        when(configuration.getKeycloakConfiguration()).thenReturn(String.format(ADAPTER_CONFIG, wireMockRule.port()));
+        when(configuration.isValidateTokenLocally()).thenReturn(false);
+
+        stubFor(post(urlEqualTo(KEYCLOAK_TOKEN_URI)).willReturn(aResponse().withStatus(400).withBody("{\"error\":\"invalid_request\"}")));
+
+        resource.doStart();
+
+        final CountDownLatch lock = new CountDownLatch(1);
+        final TestResponseHandler<TokenExchangeResponse> handler = new TestResponseHandler<>(lock);
+
+        resource.tokenExchange(
+            TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).build(),
+            handler
+        );
+        assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+
+        assertFalse(handler.getResponse().isSuccess());
+        assertNotNull(handler.getResponse().getThrowable());
+
+        verify(postRequestedFor(urlEqualTo(KEYCLOAK_TOKEN_URI)).withRequestBody(containing("subject_token=subject-token")));
     }
 
     @Test


### PR DESCRIPTION
**Description**

⚠️ Draft implementation — for local demo and flow validation only

The tokenExchange() method added to OAuth2KeycloakResource is a temporary workaround to unblock testing of the RFC 8693 token exchange flow with Gravitee MCP Proxy. It uses java.net.http.HttpClient on a Vert.x worker thread because Vertx.createHttpClient(HttpClientOptions) was removed in Vert.x 5, which this gateway runs on.

Known limitations: no connection pooling (new client per call), synchronous blocking on a worker thread, no configurable timeouts, and SSL options (trustAll, verifyHost) from the resource config are not applied.

A production-ready implementation should wait for Vert.x 5 support to be officially added to this plugin.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-token-exchange-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-keycloak/3.1.0-token-exchange-support-SNAPSHOT/gravitee-resource-oauth2-provider-keycloak-3.1.0-token-exchange-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
