### PR TITLE
docs: fix invalid JSON in Keycloak resource configuration example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,22 +63,11 @@ You can configure the resource with the following options :
 .Configuration example
 ----
 {
-    "configuration" : {
-        "keycloakConfiguration":
-            "{
-                "realm": "gravitee",
-                "auth-server-url": "http://localhost:8080/auth",
-                "ssl-required": "external",
-                "resource": "gravitee",
-                "credentials": {
-                    "secret": "f1c9ff64-abcf-4671-9ddb-4fe4a172390d"
-                },
-                "confidential-port": 0,
-                "policy-enforcer": {}
-            }"
-        },
+    "configuration": {
+        "keycloakConfiguration": "{\"realm\":\"gravitee\",\"auth-server-url\":\"http://localhost:8080/auth\",\"ssl-required\":\"external\",\"resource\":\"gravitee\",\"credentials\":{\"secret\":\"f1c9ff64-abcf-4671-9ddb-4fe4a172390d\"},\"confidential-port\":0,\"policy-enforcer\":{}}",
         "validateTokenLocally": true,
         "verifyHost": false,
         "trustAll": true
+    }
 }
 ----


### PR DESCRIPTION
## Problem

The **Configuration example** in `README.adoc` is not valid JSON. Two issues:

1. `keycloakConfiguration` was written as a multi-line, **unescaped** nested object. Because the value itself starts with `"{` and then contains more unescaped `"` characters, the JSON is malformed (the parser ends the string at `"{` and chokes on `realm`).
2. `validateTokenLocally`, `verifyHost`, and `trustAll` were placed **outside** the `configuration` object (after its closing `}`).

Anyone copying the example into the Console gets a parse error.

## Why the originally-proposed fix was also wrong

> Note for the SME (@Vikrant): the ticket proposed turning `keycloakConfiguration` into a real nested JSON object. That is **also** invalid for this resource. The field is a **string**, not an object.

Verified from the plugin source:

- **Schema** — `src/main/resources/schemas/schema-form.json`: `keycloakConfiguration` is declared `"type": "string"`. `validateTokenLocally`, `verifyHost`, and `trustAll` are sibling properties of the same `configuration` object.
- **Config model** — `OAuth2KeycloakResourceConfiguration`: `private String keycloakConfiguration;`
- **Runtime** — `OAuth2KeycloakResource` reads the value with `new ByteArrayInputStream(configuration().getKeycloakConfiguration().getBytes(...))` and passes the bytes to `KeycloakDeploymentBuilder.loadAdapterConfig(...)`. The value is parsed as a self-contained Keycloak OIDC adapter JSON document, so it has to be supplied as an escaped JSON **string**, not an inline object.

## Fix

```json
{
    "configuration": {
        "keycloakConfiguration": "{\"realm\":\"gravitee\",\"auth-server-url\":\"http://localhost:8080/auth\",\"ssl-required\":\"external\",\"resource\":\"gravitee\",\"credentials\":{\"secret\":\"f1c9ff64-abcf-4671-9ddb-4fe4a172390d\"},\"confidential-port\":0,\"policy-enforcer\":{}}",
        "validateTokenLocally": true,
        "verifyHost": false,
        "trustAll": true
    }
}
```

- `keycloakConfiguration` is now a single escaped JSON string (the Keycloak OIDC adapter config).
- `validateTokenLocally`, `verifyHost`, and `trustAll` now sit inside `configuration`.

Validated: both the outer object and the inner escaped string parse as valid JSON.

## Downstream note

This README is the canonical source for the plugin's marketplace reference. The same broken example is mirrored in the auto-generated `docs/apim/4.12/plugins/plugin-reference.md` and `docs/apim/4.11/plugins/plugin-reference.md` in `gravitee-platform-docs`. Those copies regenerate from this README, so they'll pick up the fix on the next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)